### PR TITLE
Snap is installable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@ prime
 stage
 *.snap
 .tox
+
+# Snapcraft
+.snapcraft
+__pycache__
+.cache
+
+# emacs
+*~
+\#*

--- a/snap/snap-openstack.yaml
+++ b/snap/snap-openstack.yaml
@@ -5,33 +5,32 @@ setup:
     - "{snap_common}/lock"
     - "{snap_common}/log"
     - "{snap_common}/run"
-    # If the OpenStack service has an API that runs behind uwsgi+nginx,
-    # define uwsgi and nginx etc dirs.
     - "{snap_common}/etc/nginx/sites-enabled"
     - "{snap_common}/etc/nginx/snap/sites-enabled"
     - "{snap_common}/etc/uwsgi/snap"
   templates:
-    # The gnocchi snap will likely require a template for the corresponding
-    # OpenStack service(s). For example, you may need to render a template such
-    # as the following.
     gnocchi-snap.conf.j2: "{snap_common}/etc/gnocchi/gnocchi.conf.d/gnocchi-snap.conf"
-    # If the OpenStack service has an API that runs behind uwsgi+nginx,
-    # render nginx config templates.
     gnocchi-nginx.conf.j2: "{snap_common}/etc/nginx/snap/sites-enabled/gnocchi.conf"
     nginx.conf.j2: "{snap_common}/etc/nginx/snap/nginx.conf"
 entry_points:
-  # This is where entry_points are defined for the OpenStack service. For example,
-  # the service may have a database command-line tool such as the following.
-  gnocchi-manage:
-    binary: "{snap}/bin/gnocchi-manage"
+  gnocchi-api:
+    binary: "{snap}/bin/gnocchi-api"
     config-files:
       - "{snap}/etc/gnocchi/gnocchi.conf"
     config-files-override:
       - "{snap_common}/etc/gnocchi/gnocchi.conf"
     config-dirs:
       - "{snap_common}/etc/gnocchi/gnocchi.conf.d"
-  # If the OpenStack service has an API that runs behind uwsgi+nginx, the
-  # following entry_point must be defined.
+    log-file: "{snap_common}/log/gnocchi-api.log"
+  gnocchi-metricd:
+    binary: "{snap}/bin/gnocchi-metricd"
+    config-files:
+      - "{snap}/etc/gnocchi/gnocchi.conf"
+    config-files-override:
+      - "{snap_common}/etc/gnocchi/gnocchi.conf"
+    config-dirs:
+      - "{snap_common}/etc/gnocchi/gnocchi.conf.d"
+    log-file: "{snap_common}/log/gnocchi-metricd.log"
   gnocchi-uwsgi:
     type: uwsgi
     uwsgi-dir: "{snap_common}/etc/uwsgi/snap"
@@ -46,8 +45,6 @@ entry_points:
     log-file: "{snap_common}/log/gnocchi-api.log"
     templates:
       gnocchi-api.ini.j2: "{snap_common}/etc/uwsgi/snap/gnocchi-api.ini"
-  # If the OpenStack service has an API that runs behind uwsgi+nginx, the
-  # following entry_point must be defined.
   gnocchi-nginx:
     type: nginx
     config-file: "{snap_common}/etc/nginx/snap/nginx.conf"

--- a/snap/templates/gnocchi-api.ini.j2
+++ b/snap/templates/gnocchi-api.ini.j2
@@ -4,8 +4,8 @@
 # the service it provides, and you may even need to provide multiple uwsgi files
 # if there is more than one wsgi application.
 [uwsgi]
-wsgi-file = {{ snap }}/bin/gnocchi-wsgi-file-name
-uwsgi-socket = {{ snap_common }}/run/api-name.sock
+wsgi-file = {{ snap }}/bin/gnocchi-api
+uwsgi-socket = {{ snap_common }}/run/gnocchi-api.sock
 buffer-size = 65535
 master = true
 enable-threads = true

--- a/snap/templates/gnocchi-nginx.conf.j2
+++ b/snap/templates/gnocchi-nginx.conf.j2
@@ -1,14 +1,11 @@
-# If the OpenStack service has an API that runs behind uwsgi+nginx, you'll need
-# to define this template. Be sure to update "listen" with the port number and
-# also update "api-name" for the socket.
+# gnocchi-api
 server {
-    listen 1234;
+    listen 8041;
     access_log {{ snap_common }}/log/nginx-access.log;
     error_log {{ snap_common }}/log/nginx-error.log;
     location / {
-        include uwsgi_params;
         include {{ snap }}/usr/conf/uwsgi_params;
         uwsgi_param SCRIPT_NAME '';
-        uwsgi_pass unix://{{ snap_common }}/run/api-name.sock;
+        uwsgi_pass unix://{{ snap_common }}/run/gnocchi-api.sock;
     }
 }

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,46 +1,55 @@
 name: gnocchi
-version: pike
+version: ocata
 summary: Time Series Database as a Service
 description: |
-  Gnocchi is an open-source, multi-tenant timeseries, metrics and resources database. It provides an HTTP REST interface to create and manipulate the data. It is designed to store metrics at a very large scale while providing access to metrics and resources information and history.
+  Gnocchi is an open-source, multi-tenant timeseries, metrics and
+  resources database. It provides an HTTP REST interface to create and
+  manipulate the data. It is designed to store metrics at a very large
+  scale while providing access to metrics and resources information
+  and history.
 confinement: strict
 grade: devel
 
 apps:
-  # If the OpenStack service has an API that runs behind uwsgi+nginx, the folowing
-  # app is required.
+  api:
+    command: snap-openstack gnocchi-api
+    daemon: simple
+    plugs:
+      - network-bind
+  metricd:
+      command: snap-openstack gnocchi-metricd
+      daemon: simple
+      plugs:
+        - network
   uwsgi:
     command: snap-openstack gnocchi-uwsgi
     daemon: simple
     plugs:
       - network-bind
-  # If the OpenStack service has an API that runs behind uwsgi+nginx, the folowing
-  # app is required.
   nginx:
     command: snap-openstack gnocchi-nginx
     daemon: forking
     plugs:
       - network-bind
-  # Following is an example of creating a command app.
-  manage:
-    command: snap-openstack gnocchi-manage
-    plugs:
-      - network
+  gnocchi-config-generator:
+    command: bin/gnocchi-config-generator
+  gnocchi-upgrade:
+    command: bin/gnocchi-upgrade
 
 parts:
-  # Following is an example of defining a part to build an OpenStack project
   gnocchi:
     plugin: python
     python-version: python2
-    source: http://tarballs.openstack.org/gnocchi/gnocchi-stable-pike.tar.gz
+    source: http://tarballs.openstack.org/gnocchi/gnocchi-stable-3.1.tar.gz
     python-packages:
-      # You may need to pull in additional python packages
+      - tooz
+      - oslo.db
+      - lz4
       - python-memcached
       - pymysql
-      # If the OpenStack service has an API that runs behind uwsgi+nginx, uwsgi is required.
       - uwsgi
       - git+https://github.com/openstack/snap.openstack#egg=snap.openstack
-    constraints: https://raw.githubusercontent.com/openstack/requirements/stable/pike/upper-constraints.txt
+    # constraints: https://raw.githubusercontent.com/openstack/requirements/stable/ocata/upper-constraints.txt
     build-packages:
       - gcc
       - libffi-dev
@@ -52,7 +61,7 @@ parts:
       touch $SNAPCRAFT_PART_INSTALL/lib/python2.7/site-packages/repoze/__init__.py
       export SNAP_ROOT="../../.."
       export SNAP_SITE_PACKAGES="$SNAPCRAFT_PART_INSTALL/lib/python2.7/site-packages"
-      patch -d $SNAP_SITE_PACKAGES -p1 < $SNAP_ROOT/patches/oslo-config-dirs.patch
+      # patch -d $SNAP_SITE_PACKAGES -p1 < $SNAP_ROOT/patches/oslo-config-dirs.patch
   templates:
     after: [gnocchi]
     plugin: dump
@@ -61,7 +70,7 @@ parts:
   config:
     after: [gnocchi]
     plugin: dump
-    source: http://tarballs.openstack.org/gnocchi/gnocchi-stable-pike.tar.gz
+    source: http://tarballs.openstack.org/gnocchi/gnocchi-stable-3.1.tar.gz
     organize:
       etc/*.conf: etc/gnocchi/
       etc/*.ini: etc/gnocchi/
@@ -75,8 +84,6 @@ parts:
         - etc/gnocchi/*.templates
     stage: [$etc]
     prime: [$etc]
-  # If the OpenStack service has an API that runs behind uwsgi+nginx, the following
-  # part is required.
   nginx:
     source: http://www.nginx.org/download/nginx-1.13.0.tar.gz
     plugin: autotools
@@ -99,8 +106,6 @@ parts:
       export SNAP_ROOT="../../.."
       export SNAP_SOURCE="$SNAP_ROOT/parts/nginx/build"
       patch -d $SNAP_SOURCE -p1 < $SNAP_ROOT/patches/drop-nginx-setgroups.patch
-  # If the OpenStack service has an API that runs behind uwsgi+nginx, the following
-  # part is required.
   libxml2:
     source: http://xmlsoft.org/sources/libxml2-2.9.4.tar.gz
     plugin: autotools

--- a/tests/etc/snap-gnocchi/gnocchi/gnocchi.conf
+++ b/tests/etc/snap-gnocchi/gnocchi/gnocchi.conf
@@ -399,7 +399,7 @@
 #
 
 # Indexer driver to use (string value)
-#url = <None>
+url = mysql://gnocchi:changeme@localhost/gnocchi
 
 
 [metricd]
@@ -462,6 +462,7 @@
 #
 # From gnocchi
 #
+resource_id = `uuidgen`
 
 # The listen IP for statsd (string value)
 #host = 0.0.0.0

--- a/tests/gnocchi.sh
+++ b/tests/gnocchi.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -ex
+
+DAEMONS=('snap.gnocchi.api.service', 'snap.gnocchi.metricd.service')
+ret=0
+
+sudo mysql -u root <<EOF
+DROP DATABASE IF EXISTS gnocchi;
+CREATE DATABASE gnocchi;
+GRANT ALL PRIVILEGES ON gnocchi.* TO 'gnocchi'@'localhost' \
+  IDENTIFIED BY 'changeme';
+GRANT ALL PRIVILEGES ON gnocchi.* TO 'gnocchi'@'%' \
+  IDENTIFIED BY 'changeme';
+EOF
+
+while sudo [ ! -d /var/snap/gnocchi/common/etc/gnocchi/ ]; do sleep 0.1; done;
+# TODO: this may not be the right dir -- gnocchi doesn't seem to be
+# able to see the indexer url that we set (or it might just be the
+# wrong file).
+sudo cp -r $BASE_DIR/etc/snap-gnocchi/* /var/snap/gnocchi/common/etc/
+
+gnocchi.gnocchi-upgrade
+
+for daemon in "${DAEMONS[@]}"; do
+    systemctl restart $daemon
+    TIMEOUT=50
+    while [ "$TIMEOUT" -gt 0 ]; do
+        if systemctl is-active $daemon > /dev/null; then
+            echo "OK"
+            break
+        fi
+        TIMEOUT=$((TIMEOUT - 1))
+        sleep 0.1
+    done
+
+    if [ "$TIMEOUT" -le 0 ]; then
+        echo "ERROR: ${daemon} IS NOT RUNNING"
+        ret=1
+    fi
+done
+
+exit $ret

--- a/tests/gnocchi_cleanup.sh
+++ b/tests/gnocchi_cleanup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+sudo mysql -u root <<EOF
+DROP DATABASE IF EXISTS gnocchi;
+EOF

--- a/tests/snapstack_test.py
+++ b/tests/snapstack_test.py
@@ -1,0 +1,28 @@
+import unittest
+
+from snapstack import Plan, Setup, Step
+
+class SnapstackTest(unittest.TestCase):
+
+    def test_snapstack(self):
+        '''
+        _test_snapstack_
+
+        Run a basic smoke test, utilizing our snapstack testing harness.
+
+        '''
+        gnocchi = Step(
+            snap='gnocchi',
+            script_loc='./tests/',
+            scripts=['gnocchi.sh'],
+            files=[
+                'etc/snap-gnocchi/gnocchi/gnocchi.conf'
+            ],
+            snap_store=False)
+
+        gnocchi_cleanup = Step(
+            script_loc='./tests/',
+            scripts=['gnocchi_cleanup.sh'])
+
+        plan = Plan(tests=[gnocchi], test_cleanup=[gnocchi_cleanup])
+        plan.run()

--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,19 @@ skipsdist = True
 [testenv]
 basepython = python3.5
 install_command = pip install {opts} {packages}
-passenv = HOME TERM
+passenv =
+    HOME
+    TERM
+    SNAPSTACK_HTTP_PROXY
+    SNAPSTACK_HTTPS_PROXY
 whitelist_externals =
     sudo
     snapcraft
 
 [testenv:snap]
-deps = -r{toxinidir}/requirements.txt
+deps =
+    -r{toxinidir}/requirements.txt
+    git+https://github.com/openstack-snaps/snapstack
+    pytest
 commands =
-    sudo snap install core
-    snapcraft clean
-    snapcraft snap
+    py.test -s tests/


### PR DESCRIPTION
This commit takes the cookie cutter output and fixes it up into a snap
that builds and installs.

- Added required names and such in openstack-snap.yaml and nginx and
  wsgi config templates.

- Python packages that are declared in setup.cfg and not in
  requirements.txt are now called out explicitly in the
  snapcraft.yaml. (Note: a better fix might be to update snapcraft to
  be able to parse dependencies from setup.cfg.)

- Removed upper constraints files on Python packages (and removed oslo
  patch). Gnocchi does not appear to respect the upper constraints.

- Added gnocchi-config-generator command to apps.

- Used the above to generate a default config.

- Added snapstack tests (though they don't work yet).

There's still plenty to do: snapstack tests need to be fixed up (see
the TODO in tests/gnocchi.sh), and the snap as a whole needs to be
thoroughly tested.