### PR TITLE
Use extra configuration of oslo.db and tooz

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -48,11 +48,9 @@ parts:
       - futurist
       - keystonemiddleware
       - lz4
-      - oslo.db
-      - pymysql
-      - python-memcached
+      - oslo.db[mysql]
       - sqlalchemy-utils
-      - tooz
+      - tooz[memcached]
       - uwsgi
       - git+https://github.com/openstack/snap.openstack#egg=snap.openstack
     constraints: https://raw.githubusercontent.com/openstack/requirements/stable/ocata/upper-constraints.txt


### PR DESCRIPTION
Use the in-module extra dependencies for PyMySQL and Memcache
dependencies, ensuring that any changes are automatically
reflected in the snap.