### PR TITLE
Add network-bind interface for metricd

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -25,7 +25,7 @@ apps:
     command: snap-openstack gnocchi-metricd
     daemon: simple
     plugs:
-      - network
+      - network-bind
   upgrade:
     command: snap-openstack gnocchi-upgrade
     plugs:


### PR DESCRIPTION
gnocchi-metricd fails on syscall 50 when run in strict mode;
this is a listen call supported by the network-bind interface.